### PR TITLE
Using wscdn.vaadin.com instead of cdn.virit.in.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
+                <vaadin.version>7.7.0.alpha2</vaadin.version>
+                <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
+                <vaadin.widgetset.mode>cdn</vaadin.widgetset.mode>                  
 	</properties>
 
 	<dependencies>
@@ -71,6 +74,10 @@
             <id>vaadin-addons</id>
             <url>http://maven.vaadin.com/vaadin-addons</url>
         </repository>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>http://maven.vaadin.com/vaadin-prereleases</url>
+        </repository>        
     </repositories>
 	
 	<dependencyManagement>
@@ -78,7 +85,7 @@
 			<dependency>
 				<groupId>com.vaadin</groupId>
 				<artifactId>vaadin-bom</artifactId>
-				<version>7.6.3</version>
+				<version>${vaadin.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -107,23 +114,30 @@
                 </executions>
             </plugin>
 
-            <!--Doesn't work-->
-            <!--<plugin>-->
-                <!--<groupId>com.vaadin.wscdn</groupId>-->
-                <!--<artifactId>wscdn-maven-plugin</artifactId>-->
-                <!--<version>0.0.2</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<phase>generate-sources</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>generate</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+        <plugin>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-maven-plugin</artifactId>
+            <version>${vaadin.plugin.version}</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>update-theme</goal>
+                        <goal>update-widgetset</goal>
+                        <goal>compile</goal>
+                        <goal>compile-theme</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
 
         </plugins>
 	</build>
 	
+    <pluginRepositories>
+        <pluginRepository>
+            <id>vaadin-prereleases</id>
+            <url>http://maven.vaadin.com/vaadin-prereleases</url>
+        </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/src/main/java/com/example/DemoApplication.java
+++ b/src/main/java/com/example/DemoApplication.java
@@ -2,7 +2,6 @@ package com.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @SpringBootApplication
@@ -13,18 +12,5 @@ public class DemoApplication {
 	}
 
 	@Configuration
-	static class DashboardConfiguration {
-
-        // Doesn't work
-//		@Bean
-//		public com.vaadin.wscdn.WidgetSet vaadinCdnInitializer() {
-//			return new com.vaadin.wscdn.WidgetSet();
-//		}
-
-        // Works well
-        @Bean
-        public in.virit.WidgetSet vaadinCdnInitializer() {
-            return new in.virit.WidgetSet();
-        }
-	}
+	static class DashboardConfiguration {}
 }


### PR DESCRIPTION
I created configuration to use wscdn.vaadin.com instead of virit.in. Apparently it was still trying to load ws from old URL. Note, that this is using 7.7.0.alpha2 + standard Vaadin Maven plugin with a mode-parameter.
